### PR TITLE
实现分享连接的解析和使用（只读）

### DIFF
--- a/src/main/java/com/github/zxbu/webdavteambition/client/AliYunDriverClient.java
+++ b/src/main/java/com/github/zxbu/webdavteambition/client/AliYunDriverClient.java
@@ -1,6 +1,8 @@
 package com.github.zxbu.webdavteambition.client;
 
 import com.github.zxbu.webdavteambition.config.AliYunDriveProperties;
+import com.github.zxbu.webdavteambition.model.ShareTokenRequest;
+import com.github.zxbu.webdavteambition.model.result.ShareTokenResult;
 import com.github.zxbu.webdavteambition.util.JsonUtil;
 import net.sf.webdav.exceptions.WebdavException;
 import okhttp3.*;
@@ -18,6 +20,8 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -25,6 +29,7 @@ public class AliYunDriverClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(AliYunDriverClient.class);
     private OkHttpClient okHttpClient;
     private AliYunDriveProperties aliYunDriveProperties;
+    private Map<String, ShareTokenResult> shareTokenMapping = new HashMap<>();
 
     public AliYunDriverClient(AliYunDriveProperties aliYunDriveProperties) {
 
@@ -141,10 +146,18 @@ public class AliYunDriverClient {
     }
 
     public String post(String url, Object body) {
+        return post(url, body, null);
+    }
+
+    public String post(String url, Object body, String shareId) {
         String bodyAsJson = JsonUtil.toJson(body);
-        Request request = new Request.Builder()
+        Request.Builder requestBuilder = new Request.Builder()
                 .post(RequestBody.create(MediaType.parse("application/json; charset=utf-8"), bodyAsJson))
-                .url(getTotalUrl(url)).build();
+                .url(getTotalUrl(url));
+        if (shareId != null){
+            requestBuilder.header("X-Share-Token", readShareToken(shareId));
+        }
+        Request request = requestBuilder.build();
         try (Response response = okHttpClient.newCall(request).execute()){
             LOGGER.info("post {}, body {}, code {}", url, bodyAsJson, response.code());
             if (!response.isSuccessful()) {
@@ -205,6 +218,19 @@ public class AliYunDriverClient {
             return url;
         }
         return aliYunDriveProperties.getUrl() + url;
+    }
+
+    public synchronized String readShareToken(String shareId){
+        ShareTokenResult result = shareTokenMapping.get(shareId);
+        if (result != null && result.getExpire_time().after(new Date())){
+            return result.getShare_token();
+        }
+        ShareTokenRequest request = new ShareTokenRequest();
+        request.setShare_id(shareId);
+        String resultString = post("/share_link/get_share_token", request);
+        result = JsonUtil.readValue(resultString, ShareTokenResult.class);
+        shareTokenMapping.put(shareId, result);
+        return result.getShare_token();
     }
 
     private void deleteRefreshTokenFile() {

--- a/src/main/java/com/github/zxbu/webdavteambition/config/AliYunDriverCronTask.java
+++ b/src/main/java/com/github/zxbu/webdavteambition/config/AliYunDriverCronTask.java
@@ -19,7 +19,7 @@ public class AliYunDriverCronTask {
     public void refreshToken() {
         try {
             TFile root = aliYunDriverClientService.getTFileByPath("/");
-            aliYunDriverClientService.getTFiles(root.getFile_id(), null);
+            aliYunDriverClientService.getTFiles(root.getFile_id(), null, null);
         } catch (Exception e) {
             // nothing
         }

--- a/src/main/java/com/github/zxbu/webdavteambition/config/AliYunDriverCronTask.java
+++ b/src/main/java/com/github/zxbu/webdavteambition/config/AliYunDriverCronTask.java
@@ -19,7 +19,7 @@ public class AliYunDriverCronTask {
     public void refreshToken() {
         try {
             TFile root = aliYunDriverClientService.getTFileByPath("/");
-            aliYunDriverClientService.getTFiles(root.getFile_id());
+            aliYunDriverClientService.getTFiles(root.getFile_id(), null);
         } catch (Exception e) {
             // nothing
         }

--- a/src/main/java/com/github/zxbu/webdavteambition/model/DownloadRequest.java
+++ b/src/main/java/com/github/zxbu/webdavteambition/model/DownloadRequest.java
@@ -2,7 +2,9 @@ package com.github.zxbu.webdavteambition.model;
 
 public class DownloadRequest {
     private String drive_id;
+    private String share_id;
     private String file_id;
+    private String shareToken;
     private Integer expire_sec = 14400;
 
     public String getDrive_id() {
@@ -27,5 +29,23 @@ public class DownloadRequest {
 
     public void setExpire_sec(Integer expire_sec) {
         this.expire_sec = expire_sec;
+    }
+
+    public String getShare_id() {
+        return share_id;
+    }
+
+    public DownloadRequest setShare_id(String share_id) {
+        this.share_id = share_id;
+        return this;
+    }
+
+    public String getShareToken() {
+        return shareToken;
+    }
+
+    public DownloadRequest setShareToken(String shareToken) {
+        this.shareToken = shareToken;
+        return this;
     }
 }

--- a/src/main/java/com/github/zxbu/webdavteambition/model/FileListRequest.java
+++ b/src/main/java/com/github/zxbu/webdavteambition/model/FileListRequest.java
@@ -2,12 +2,22 @@ package com.github.zxbu.webdavteambition.model;
 
 public class FileListRequest extends Page{
     private String drive_id;
+    private String share_id;
     private Boolean all = false;
     private String fields = "*";
     private String image_thumbnail_process = "image/resize,w_400/format,jpeg";
     private String image_url_process = "image/resize,w_1920/format,jpeg";
     private String parent_file_id;
     private String video_thumbnail_process = "video/snapshot,t_0,f_jpg,ar_auto,w_300";
+
+    public String getShare_id() {
+        return share_id;
+    }
+
+    public FileListRequest setShare_id(String share_id) {
+        this.share_id = share_id;
+        return this;
+    }
 
     public String getDrive_id() {
         return drive_id;

--- a/src/main/java/com/github/zxbu/webdavteambition/model/ShareTokenRequest.java
+++ b/src/main/java/com/github/zxbu/webdavteambition/model/ShareTokenRequest.java
@@ -1,0 +1,24 @@
+package com.github.zxbu.webdavteambition.model;
+
+public class ShareTokenRequest {
+    private String share_id;
+    private String share_pwd;
+
+    public String getShare_id() {
+        return share_id;
+    }
+
+    public ShareTokenRequest setShare_id(String share_id) {
+        this.share_id = share_id;
+        return this;
+    }
+
+    public String getShare_pwd() {
+        return share_pwd;
+    }
+
+    public ShareTokenRequest setShare_pwd(String share_pwd) {
+        this.share_pwd = share_pwd;
+        return this;
+    }
+}

--- a/src/main/java/com/github/zxbu/webdavteambition/model/result/ShareTokenResult.java
+++ b/src/main/java/com/github/zxbu/webdavteambition/model/result/ShareTokenResult.java
@@ -1,0 +1,36 @@
+package com.github.zxbu.webdavteambition.model.result;
+
+import java.util.Date;
+
+public class ShareTokenResult {
+    private String share_token;
+    private Integer expires_in;
+    private Date expire_time;
+
+    public Date getExpire_time() {
+        return expire_time;
+    }
+
+    public ShareTokenResult setExpire_time(Date expire_time) {
+        this.expire_time = expire_time;
+        return this;
+    }
+
+    public String getShare_token() {
+        return share_token;
+    }
+
+    public ShareTokenResult setShare_token(String share_token) {
+        this.share_token = share_token;
+        return this;
+    }
+
+    public Integer getExpires_in() {
+        return expires_in;
+    }
+
+    public ShareTokenResult setExpires_in(Integer expires_in) {
+        this.expires_in = expires_in;
+        return this;
+    }
+}

--- a/src/main/java/com/github/zxbu/webdavteambition/model/result/TFile.java
+++ b/src/main/java/com/github/zxbu/webdavteambition/model/result/TFile.java
@@ -21,6 +21,8 @@ public class TFile {
     private Long size;
     private String download_url;
     private String share_id;
+    private String share_password;
+    private String origin_file_id;
 
     public Date getCreated_at() {
         return created_at;
@@ -156,6 +158,24 @@ public class TFile {
 
     public TFile setShare_id(String share_id) {
         this.share_id = share_id;
+        return this;
+    }
+
+    public String getOrigin_file_id() {
+        return origin_file_id;
+    }
+
+    public TFile setOrigin_file_id(String origin_file_id) {
+        this.origin_file_id = origin_file_id;
+        return this;
+    }
+
+    public String getShare_password() {
+        return share_password;
+    }
+
+    public TFile setShare_password(String share_password) {
+        this.share_password = share_password;
         return this;
     }
 }

--- a/src/main/java/com/github/zxbu/webdavteambition/model/result/TFile.java
+++ b/src/main/java/com/github/zxbu/webdavteambition/model/result/TFile.java
@@ -20,6 +20,7 @@ public class TFile {
     private String url;
     private Long size;
     private String download_url;
+    private String share_id;
 
     public Date getCreated_at() {
         return created_at;
@@ -147,5 +148,14 @@ public class TFile {
 
     public void setUpdated_at(Date updated_at) {
         this.updated_at = updated_at;
+    }
+
+    public String getShare_id() {
+        return share_id;
+    }
+
+    public TFile setShare_id(String share_id) {
+        this.share_id = share_id;
+        return this;
     }
 }

--- a/src/main/java/com/github/zxbu/webdavteambition/store/AliYunDriverClientService.java
+++ b/src/main/java/com/github/zxbu/webdavteambition/store/AliYunDriverClientService.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -35,7 +36,7 @@ public class AliYunDriverClientService {
     private static String rootPath = "/";
     private static int chunkSize = 10485760; // 10MB
     private TFile rootTFile = null;
-    private Pattern sharePatten = Pattern.compile("^.*卍([a-zA-Z0-9]{11})$");
+    private final Pattern shareNamePatten = Pattern.compile("^.*!(?<shareId>[a-zA-Z0-9]{11})(?>$|:(?<password>[a-zA-Z0-9]{4})$)");
 
     private static Cache<String, Set<TFile>> tFilesCache = Caffeine.newBuilder()
             .initialCapacity(128)
@@ -53,10 +54,10 @@ public class AliYunDriverClientService {
         AliYunDriverFileSystemStore.setBean(this);
     }
 
-    public Set<TFile> getTFiles(String nodeId, String shareId) {
+    public Set<TFile> getTFiles(String nodeId, String shareId, String sharePassword) {
         Set<TFile> tFiles = tFilesCache.get(shareId + ":" + nodeId, key -> {
             // 获取真实的文件列表
-            return getTFiles2(nodeId, shareId);
+            return getTFiles2(nodeId, shareId, sharePassword);
         });
         Set<TFile> all = new LinkedHashSet<>(tFiles);
         // 获取上传中的文件列表
@@ -65,11 +66,12 @@ public class AliYunDriverClientService {
         return all;
     }
 
-    private Set<TFile> getTFiles2(String nodeId, String shareId) {
-        List<TFile> tFileList = fileListFromApi(nodeId, null, new ArrayList<>(), shareId);
+    private Set<TFile> getTFiles2(String nodeId, String shareId, String sharePassword) {
+        List<TFile> tFileList = fileListFromApi(nodeId, null, new ArrayList<>(), shareId, sharePassword);
         tFileList.sort(Comparator.comparing(TFile::getUpdated_at).reversed());
         Set<TFile> tFileSets = new LinkedHashSet<>();
         for (TFile tFile : tFileList) {
+            tFile.setShare_password(sharePassword);
             if (!tFileSets.add(tFile)) {
                 LOGGER.info("当前目录下{} 存在同名文件：{}，文件大小：{}", nodeId, tFile.getName(), tFile.getSize());
             }
@@ -78,7 +80,7 @@ public class AliYunDriverClientService {
         return tFileSets;
     }
 
-    private List<TFile> fileListFromApi(String nodeId, String marker, List<TFile> all, String shareId) {
+    private List<TFile> fileListFromApi(String nodeId, String marker, List<TFile> all, String shareId, String sharePassword) {
         FileListRequest listQuery = new FileListRequest();
         listQuery.setMarker(marker);
         listQuery.setLimit(100);
@@ -90,14 +92,20 @@ public class AliYunDriverClientService {
         } else {
             listQuery.setDrive_id(client.getDriveId());
         }
-        String json = client.post("/file/list", listQuery, shareId);
-        TFileListResult<TFile> tFileListResult = JsonUtil.readValue(json, new TypeReference<TFileListResult<TFile>>() {
-        });
+        String json;
+        try {
+            json = client.post("/file/list", listQuery, shareId, sharePassword);
+        } catch (WebdavException e){
+            // 无法获取列表可能是 shareId 已经失效，与其报错不如返回空，特别是使用 dav 挂载时候，报错会导致 IO 错误无法删除目录
+            e.printStackTrace();
+            return Collections.emptyList();
+        }
+        TFileListResult<TFile> tFileListResult = JsonUtil.readValue(json, new TypeReference<TFileListResult<TFile>>() {});
         all.addAll(tFileListResult.getItems());
         if (!StringUtils.hasLength(tFileListResult.getNext_marker())) {
             return all;
         }
-        return fileListFromApi(nodeId, tFileListResult.getNext_marker(), all, shareId);
+        return fileListFromApi(nodeId, tFileListResult.getNext_marker(), all, shareId, sharePassword);
     }
 
 
@@ -219,7 +227,7 @@ public class AliYunDriverClientService {
         TFile tFile = getTFileByPath(sourcePath);
         RenameRequest renameRequest = new RenameRequest();
         renameRequest.setDrive_id(client.getDriveId());
-        renameRequest.setFile_id(tFile.getFile_id());
+        renameRequest.setFile_id(tFile.getOrigin_file_id() != null ? tFile.getOrigin_file_id() : tFile.getFile_id());
         renameRequest.setName(newName);
         client.post("/file/update", renameRequest);
         clearCache();
@@ -233,7 +241,7 @@ public class AliYunDriverClientService {
         TFile targetTFile = getTFileByPath(targetPath);
         MoveRequest moveRequest = new MoveRequest();
         moveRequest.setDrive_id(client.getDriveId());
-        moveRequest.setFile_id(sourceTFile.getFile_id());
+        moveRequest.setFile_id(sourceTFile.getOrigin_file_id() != null ? sourceTFile.getOrigin_file_id() : sourceTFile.getFile_id());
         moveRequest.setTo_parent_file_id(targetTFile.getFile_id());
         client.post("/file/move", moveRequest);
         clearCache();
@@ -247,7 +255,7 @@ public class AliYunDriverClientService {
         }
         RemoveRequest removeRequest = new RemoveRequest();
         removeRequest.setDrive_id(client.getDriveId());
-        removeRequest.setFile_id(tFile.getFile_id());
+        removeRequest.setFile_id(tFile.getOrigin_file_id() != null ? tFile.getOrigin_file_id() : tFile.getFile_id());
         client.post("/recyclebin/trash", removeRequest);
         clearCache();
     }
@@ -301,9 +309,9 @@ public class AliYunDriverClientService {
             DownloadRequest downloadRequest = new DownloadRequest();
             downloadRequest.setFile_id(file.getFile_id());
             downloadRequest.setShare_id(file.getShare_id());
-            downloadRequest.setShareToken(client.readShareToken(file.getShare_id()));
+            downloadRequest.setShareToken(client.readShareToken(file.getShare_id(), file.getShare_password()));
             downloadRequest.setExpire_sec(600);
-            String json = client.post("/file/get_share_link_download_url", downloadRequest, file.getShare_id());
+            String json = client.post("/file/get_share_link_download_url", downloadRequest, file.getShare_id(), file.getShare_password());
             Object url = JsonUtil.getJsonNodeValue(json, "url");
             LOGGER.debug("{} url = {}", path, url);
             return client.download(url.toString(), request, size);
@@ -322,11 +330,7 @@ public class AliYunDriverClientService {
         if (tFile == null ) {
             return null;
         }
-        Matcher matcher = sharePatten.matcher(pathInfo.getName());
-        if (matcher.find()){
-            return getShareRootTFile(matcher.group(1), pathInfo.getName());
-        }
-        return getNodeIdByParentId(tFile.getFile_id(), tFile.getShare_id(), pathInfo.getName());
+        return getNodeIdByParentId(tFile.getFile_id(), pathInfo.getName(), tFile.getShare_id(), tFile.getShare_password());
     }
 
 
@@ -365,7 +369,7 @@ public class AliYunDriverClientService {
         return rootTFile;
     }
 
-    private TFile getShareRootTFile(String shareId, String name){
+    private TFile getShareRootTFile(String shareId, String name, String originFileId, String sharePassword){
         TFile rootTFile = new TFile();
         rootTFile.setName(name);
         rootTFile.setFile_id("root");
@@ -373,14 +377,21 @@ public class AliYunDriverClientService {
         rootTFile.setUpdated_at(new Date());
         rootTFile.setType("folder");
         rootTFile.setShare_id(shareId);
+        rootTFile.setOrigin_file_id(originFileId);
+        rootTFile.setShare_password(sharePassword);
         return rootTFile;
     }
 
-    private TFile getNodeIdByParentId(String parentId, String shareId, String name) {
-        Set<TFile> tFiles = getTFiles(parentId, shareId);
+    private TFile getNodeIdByParentId(String parentId, String name, String shareId, String sharePassword) {
+        Set<TFile> tFiles = getTFiles(parentId, shareId, sharePassword);
         for (TFile tFile : tFiles) {
             if (tFile.getName().equals(name)) {
-                return tFile;
+                Matcher matcher = shareNamePatten.matcher(name);
+                if (matcher.find()){
+                    return getShareRootTFile(matcher.group("shareId"), name, tFile.getFile_id(), matcher.group("password"));
+                } else {
+                    return tFile;
+                }
             }
         }
         return null;

--- a/src/main/java/com/github/zxbu/webdavteambition/store/AliYunDriverFileSystemStore.java
+++ b/src/main/java/com/github/zxbu/webdavteambition/store/AliYunDriverFileSystemStore.java
@@ -136,7 +136,7 @@ public class AliYunDriverFileSystemStore implements IWebdavStore {
         if (tFile.getType().equals(FileType.file.name())) {
             return new String[0];
         }
-        Set<TFile> tFileList = aliYunDriverClientService.getTFiles(tFile.getFile_id());
+        Set<TFile> tFileList = aliYunDriverClientService.getTFiles(tFile.getFile_id(), tFile.getShare_id());
         return tFileList.stream().map(TFile::getName).toArray(String[]::new);
     }
 

--- a/src/main/java/com/github/zxbu/webdavteambition/store/AliYunDriverFileSystemStore.java
+++ b/src/main/java/com/github/zxbu/webdavteambition/store/AliYunDriverFileSystemStore.java
@@ -21,11 +21,14 @@ import java.security.Principal;
 import java.util.Enumeration;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 public class AliYunDriverFileSystemStore implements IWebdavStore {
     private static final Logger LOGGER = LoggerFactory.getLogger(AliYunDriverFileSystemStore.class);
 
     private static AliYunDriverClientService aliYunDriverClientService;
+
+    private final Pattern inSharePatten = Pattern.compile(".*!(?<shareId>[a-zA-Z0-9]{11})(?>\\/.|:(?<password>[a-zA-Z0-9]{4})\\/.)");
 
     public AliYunDriverFileSystemStore(File file) {
     }
@@ -68,14 +71,18 @@ public class AliYunDriverFileSystemStore implements IWebdavStore {
     @Override
     public void createFolder(ITransaction transaction, String folderUri) {
         LOGGER.info("createFolder {}", folderUri);
-
+        if (inSharePatten.matcher(folderUri).find()){
+            throw new WebdavException("共享目录不可写");
+        }
         aliYunDriverClientService.createFolder(folderUri);
     }
 
     @Override
     public void createResource(ITransaction transaction, String resourceUri) {
         LOGGER.info("createResource {}", resourceUri);
-
+        if (inSharePatten.matcher(resourceUri).find()){
+            throw new WebdavException("共享目录不可写");
+        }
     }
 
     @Override
@@ -103,6 +110,9 @@ public class AliYunDriverFileSystemStore implements IWebdavStore {
     @Override
     public long setResourceContent(ITransaction transaction, String resourceUri, InputStream content, String contentType, String characterEncoding) {
         LOGGER.info("setResourceContent {}", resourceUri);
+        if (inSharePatten.matcher(resourceUri).find()){
+            throw new WebdavException("共享目录不可写");
+        }
         HttpServletRequest request = transaction.getRequest();
         HttpServletResponse response = transaction.getResponse();
 
@@ -136,7 +146,7 @@ public class AliYunDriverFileSystemStore implements IWebdavStore {
         if (tFile.getType().equals(FileType.file.name())) {
             return new String[0];
         }
-        Set<TFile> tFileList = aliYunDriverClientService.getTFiles(tFile.getFile_id(), tFile.getShare_id());
+        Set<TFile> tFileList = aliYunDriverClientService.getTFiles(tFile.getFile_id(), tFile.getShare_id(), tFile.getShare_password());
         return tFileList.stream().map(TFile::getName).toArray(String[]::new);
     }
 
@@ -160,13 +170,20 @@ public class AliYunDriverFileSystemStore implements IWebdavStore {
     @Override
     public void removeObject(ITransaction transaction, String uri) {
         LOGGER.info("removeObject: {}", uri);
+        if (inSharePatten.matcher(uri).find()){
+            // 对于共享文件夹内的删除进行跳过，因为在删除共享目录时候用户使用 rm -r 'Test!Pfb5mXu2TLK' 之类的命令或者使用 GUI 删除都会递归删除子文件，如果这里报错就会导致本身的文件夹也无法删除
+            LOGGER.info("removeObject skip: {}", uri);
+            return;
+        }
         aliYunDriverClientService.remove(uri);
     }
 
     @Override
     public boolean moveObject(ITransaction transaction, String destinationPath, String sourcePath) {
         LOGGER.info("moveObject, destinationPath={}, sourcePath={}", destinationPath, sourcePath);
-
+        if (inSharePatten.matcher(destinationPath).find() || inSharePatten.matcher(sourcePath).find()){
+            throw new WebdavException("共享目录不可写");
+        }
         PathInfo destinationPathInfo = aliYunDriverClientService.getPathInfo(destinationPath);
         PathInfo sourcePathInfo = aliYunDriverClientService.getPathInfo(sourcePath);
         // 名字相同，说明是移动目录


### PR DESCRIPTION
这个 PR 新增了一个非常实用的功能，对分享连接的解析和只读的支持。
具体使用方法如下：

1. 获取一个别人分享的连接，比如 https://www.aliyundrive.com/s/2hZNhLLBfuC
2. 在使用了本项目的网盘任意位置建一个空文件夹，命名以 卍2hZNhLLBfuC 结尾，卍号之前的内容可以根据需要设置
3. 使用本项目的提供的 WebDAV 访问本文件夹，将可以访问到对应的分享内容
4. 同时也支持嵌套的引用共享文件夹，比如在 https://www.aliyundrive.com/s/2hZNhLLBfuC 中还存在 卍2hZNhLLBfuB 也可以解析

还存在以下弊端

1. 写入的内容会被存储于自己网盘的根目录，极度不建议写入内容。

此功能可以同时解决两个难题，一个是转存的文件分享者更新后不会一起更新，二是转存文件占用自己的网盘容量。